### PR TITLE
Add response sanitization in middleware

### DIFF
--- a/security/validation_middleware.py
+++ b/security/validation_middleware.py
@@ -3,6 +3,8 @@
 from flask import request, Response
 from typing import Callable
 
+from .xss_validator import XSSPrevention
+
 from config.dynamic_config import dynamic_config
 
 from .validation_exceptions import ValidationError
@@ -49,4 +51,7 @@ class ValidationMiddleware:
         return None
 
     def sanitize_response(self, response: Response) -> Response:
+        body = response.get_data(as_text=True)
+        sanitized = XSSPrevention.sanitize_html_output(body)
+        response.set_data(sanitized)
         return response

--- a/tests/security/test_validators.py
+++ b/tests/security/test_validators.py
@@ -74,3 +74,17 @@ def test_malicious_query_rejected():
     client = app.test_client()
     resp = client.get("/?q=%3Cscript%3E")
     assert resp.status_code == 400
+
+
+def test_response_sanitized():
+    app = _create_test_app()
+
+    @app.route("/unsafe")
+    def unsafe():
+        return "<script>alert('xss')</script>"
+
+    client = app.test_client()
+    resp = client.get("/unsafe")
+    data = resp.get_data(as_text=True)
+    assert "<script>" not in data
+    assert "&lt;script&gt;" in data


### PR DESCRIPTION
## Summary
- sanitize HTML in HTTP responses via XSSPrevention
- test middleware response sanitization

## Testing
- `pytest tests/security/test_validators.py::test_response_sanitized -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686382c4f65883208206baf817b63e33