### PR TITLE
Make AI suggestion confidences configurable

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -70,6 +70,17 @@ class SampleFilesConfig:
 
 
 @dataclass
+class AISuggestionsConfig:
+    """Confidence values for AI column suggestions"""
+
+    person_id_confidence: float = 0.7
+    door_id_confidence: float = 0.7
+    timestamp_confidence: float = 0.8
+    access_result_confidence: float = 0.7
+    token_id_confidence: float = 0.6
+
+
+@dataclass
 class Config:
     """Main configuration object"""
 
@@ -77,6 +88,7 @@ class Config:
     database: DatabaseConfig = field(default_factory=DatabaseConfig)
     security: SecurityConfig = field(default_factory=SecurityConfig)
     sample_files: SampleFilesConfig = field(default_factory=SampleFilesConfig)
+    ai_suggestions: AISuggestionsConfig = field(default_factory=AISuggestionsConfig)
     environment: str = "development"
 
 
@@ -215,6 +227,24 @@ class ConfigManager:
                 "json_path", self.config.sample_files.json_path
             )
 
+        if "ai_suggestions" in yaml_config:
+            ai_data = yaml_config["ai_suggestions"]
+            self.config.ai_suggestions.person_id_confidence = ai_data.get(
+                "person_id_confidence", self.config.ai_suggestions.person_id_confidence
+            )
+            self.config.ai_suggestions.door_id_confidence = ai_data.get(
+                "door_id_confidence", self.config.ai_suggestions.door_id_confidence
+            )
+            self.config.ai_suggestions.timestamp_confidence = ai_data.get(
+                "timestamp_confidence", self.config.ai_suggestions.timestamp_confidence
+            )
+            self.config.ai_suggestions.access_result_confidence = ai_data.get(
+                "access_result_confidence", self.config.ai_suggestions.access_result_confidence
+            )
+            self.config.ai_suggestions.token_id_confidence = ai_data.get(
+                "token_id_confidence", self.config.ai_suggestions.token_id_confidence
+            )
+
     def _apply_env_overrides(self) -> None:
         """Apply environment variable overrides"""
         # App overrides
@@ -339,6 +369,10 @@ class ConfigManager:
         """Get sample file path configuration"""
         return self.config.sample_files
 
+    def get_ai_suggestions_config(self) -> AISuggestionsConfig:
+        """Get AI suggestions configuration"""
+        return self.config.ai_suggestions
+
 
 # Global configuration instance
 _config_manager: Optional[ConfigManager] = None
@@ -380,6 +414,11 @@ def get_sample_files_config() -> SampleFilesConfig:
     return get_config().get_sample_files_config()
 
 
+def get_ai_suggestions_config() -> AISuggestionsConfig:
+    """Get AI suggestion configuration"""
+    return get_config().get_ai_suggestions_config()
+
+
 # Export main classes and functions
 __all__ = [
     "Config",
@@ -387,6 +426,7 @@ __all__ = [
     "DatabaseConfig",
     "SecurityConfig",
     "SampleFilesConfig",
+    "AISuggestionsConfig",
     "ConfigManager",
     "get_config",
     "reload_config",
@@ -394,4 +434,5 @@ __all__ = [
     "get_database_config",
     "get_security_config",
     "get_sample_files_config",
+    "get_ai_suggestions_config",
 ]

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,6 +21,13 @@ sample_files:
   csv_path: "data/sample_data.csv"
   json_path: "data/sample_data.json"
 
+ai_suggestions:
+  person_id_confidence: 0.7
+  door_id_confidence: 0.7
+  timestamp_confidence: 0.8
+  access_result_confidence: 0.7
+  token_id_confidence: 0.6
+
 logging:
   level: "INFO"
   format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/services/ai_suggestions.py
+++ b/services/ai_suggestions.py
@@ -1,6 +1,28 @@
 """Simple column suggestion heuristics used across the app."""
 from typing import Dict, List, Any
 
+from config.config import get_ai_suggestions_config
+
+# Load default confidences from configuration
+_CFG = get_ai_suggestions_config()
+
+PERSON_ID_CONFIDENCE = _CFG.person_id_confidence
+DOOR_ID_CONFIDENCE = _CFG.door_id_confidence
+TIMESTAMP_CONFIDENCE = _CFG.timestamp_confidence
+ACCESS_RESULT_CONFIDENCE = _CFG.access_result_confidence
+TOKEN_ID_CONFIDENCE = _CFG.token_id_confidence
+
+
+def reload_constants() -> None:
+    """Reload constants from configuration."""
+    cfg = get_ai_suggestions_config()
+    global PERSON_ID_CONFIDENCE, DOOR_ID_CONFIDENCE, TIMESTAMP_CONFIDENCE, ACCESS_RESULT_CONFIDENCE, TOKEN_ID_CONFIDENCE
+    PERSON_ID_CONFIDENCE = cfg.person_id_confidence
+    DOOR_ID_CONFIDENCE = cfg.door_id_confidence
+    TIMESTAMP_CONFIDENCE = cfg.timestamp_confidence
+    ACCESS_RESULT_CONFIDENCE = cfg.access_result_confidence
+    TOKEN_ID_CONFIDENCE = cfg.token_id_confidence
+
 
 def generate_column_suggestions(columns: List[str]) -> Dict[str, Dict[str, Any]]:
     """Return suggested standard fields for each column name."""
@@ -11,19 +33,19 @@ def generate_column_suggestions(columns: List[str]) -> Dict[str, Dict[str, Any]]
         suggestion = {"field": "", "confidence": 0.0}
 
         if any(keyword in column_lower for keyword in ["person", "user", "employee", "name"]):
-            suggestion = {"field": "person_id", "confidence": 0.7}
+            suggestion = {"field": "person_id", "confidence": PERSON_ID_CONFIDENCE}
         elif any(keyword in column_lower for keyword in ["door", "location", "device", "room"]):
-            suggestion = {"field": "door_id", "confidence": 0.7}
+            suggestion = {"field": "door_id", "confidence": DOOR_ID_CONFIDENCE}
         elif any(keyword in column_lower for keyword in ["time", "date", "stamp"]):
-            suggestion = {"field": "timestamp", "confidence": 0.8}
+            suggestion = {"field": "timestamp", "confidence": TIMESTAMP_CONFIDENCE}
         elif any(keyword in column_lower for keyword in ["result", "status", "access"]):
-            suggestion = {"field": "access_result", "confidence": 0.7}
+            suggestion = {"field": "access_result", "confidence": ACCESS_RESULT_CONFIDENCE}
         elif any(keyword in column_lower for keyword in ["token", "badge", "card"]):
-            suggestion = {"field": "token_id", "confidence": 0.6}
+            suggestion = {"field": "token_id", "confidence": TOKEN_ID_CONFIDENCE}
 
         suggestions[column] = suggestion
 
     return suggestions
 
 
-__all__ = ["generate_column_suggestions"]
+__all__ = ["generate_column_suggestions", "reload_constants"]

--- a/tests/test_ai_suggestions.py
+++ b/tests/test_ai_suggestions.py
@@ -1,5 +1,6 @@
 import pytest
-from services.ai_suggestions import generate_column_suggestions
+from services.ai_suggestions import generate_column_suggestions, reload_constants
+from config.config import reload_config
 
 
 def test_basic_suggestions():
@@ -17,3 +18,13 @@ def test_unknown_column_returns_empty():
     suggestions = generate_column_suggestions(["Mystery"])
     assert suggestions["Mystery"]["field"] == ""
     assert suggestions["Mystery"]["confidence"] == 0.0
+
+
+def test_confidence_values_reloadable():
+    """Confidence values should reflect configuration changes."""
+    cfg = reload_config()
+    cfg.config.ai_suggestions.person_id_confidence = 0.9
+    reload_constants()
+
+    suggestions = generate_column_suggestions(["person id"])
+    assert suggestions["person id"]["confidence"] == 0.9


### PR DESCRIPTION
## Summary
- add `AISuggestionsConfig` dataclass and expose getter
- load ai suggestion confidence defaults from `config.yaml`
- add reloadable constants in `ai_suggestions` service
- test that confidences can be reloaded from config

## Testing
- `python -m py_compile services/ai_suggestions.py config/config.py tests/test_ai_suggestions.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686382dca7408320b4781c4c8fa7fd10