### PR TITLE
Update handle_analysis_buttons auto run unique patterns

### DIFF
--- a/pages/deep_analytics/callbacks.py
+++ b/pages/deep_analytics/callbacks.py
@@ -383,7 +383,11 @@ def run_unique_patterns_analysis():
         )
 
 def handle_analysis_buttons(security_n, trends_n, behavior_n, anomaly_n, suggests_n, quality_n, unique_n, data_source):
-    """Handle analysis button clicks and dispatch to helper functions."""
+    """Handle analysis button clicks and auto-run Unique Patterns on load."""
+
+    # Auto-run Unique Patterns when data source is available and no button clicked yet
+    if not callback_context.triggered and data_source and data_source != "none":
+        return run_unique_patterns_analysis()
 
     if not callback_context.triggered:
         return get_initial_message_safe()
@@ -418,7 +422,7 @@ def handle_analysis_buttons(security_n, trends_n, behavior_n, anomaly_n, suggest
             "anomaly": lambda: run_service_analysis(data_source, "anomaly"),
         }
         return dispatch[analysis_type]()
-    except Exception as e:  # pragma: no cover - catch unforeseen errors
+    except Exception as e:
         return dbc.Alert(f"Analysis failed: {str(e)}", color="danger")
 
 
@@ -469,7 +473,9 @@ def register_callbacks(manager: UnifiedCallbackCoordinator) -> None:
             Input("unique-patterns-btn", "n_clicks"),
         ],
         [State("analytics-data-source", "value")],
-        prevent_initial_call=True,
+        # Allow initial call so Unique Patterns runs automatically when a data
+        # source value is present
+        prevent_initial_call=False,
         callback_id="handle_analysis_buttons",
         component_name="deep_analytics",
     )(handle_analysis_buttons)


### PR DESCRIPTION
## Summary
- auto-run unique pattern analysis when analytics page loads with a data source
- fallback to existing logic if no data source provided
- allow the callback to run on page load so the automatic analysis appears

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686398ead1888320b8a1e27558ba6c42