### PR TITLE
Secure pickle loading for ConsolidatedLearningService

### DIFF
--- a/docs/device_learning_service.md
+++ b/docs/device_learning_service.md
@@ -34,10 +34,13 @@ when similar files are uploaded again.
 
 Older versions of the dashboard stored learned mappings in
 `data/learned_mappings.pkl`. The current service writes mappings to
-`data/learned_mappings.json` instead and will automatically migrate the
-pickle file if it exists. If you need to recreate the legacy
-`learned_mappings.pkl` for testing, run the application and save some
-device mappings, then manually convert the JSON output:
+`data/learned_mappings.json` instead and can migrate the pickle file on
+startup **only when explicitly allowed**. Pickle loading is disabled by
+default for security. Pass `allow_pickle=True` when initializing
+`ConsolidatedLearningService` if you need to import data from the legacy
+format. To recreate `learned_mappings.pkl` for testing, run the
+application and save some device mappings, then manually convert the JSON
+output:
 
 ```bash
 python app.py  # upload a file and confirm mappings


### PR DESCRIPTION
## Summary
- add `allow_pickle` option to ConsolidatedLearningService
- warn when legacy pickle file is ignored
- document how to enable pickle migration
- test default and opt-in pickle loading behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68639ae7173c8320be589b84f7f9842f