### PR TITLE
Enable Unique Patterns auto load

### DIFF
--- a/pages/deep_analytics/callbacks.py
+++ b/pages/deep_analytics/callbacks.py
@@ -473,7 +473,8 @@ def register_callbacks(manager: UnifiedCallbackCoordinator) -> None:
             Input("unique-patterns-btn", "n_clicks"),
         ],
         [State("analytics-data-source", "value")],
-        prevent_initial_call=True,
+        # Allow initial call so Unique Patterns runs on page load
+        prevent_initial_call=False,
         callback_id="handle_analysis_buttons",
         component_name="deep_analytics",
     )(handle_analysis_buttons)


### PR DESCRIPTION
## Summary
- automatically run Unique Patterns analysis on initial page load

## Testing
- `black . --check` *(fails: would reformat many files)*
- `flake8 .` *(fails: command not found)*
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863a5c29e188320950df76d12889a47