### PR TITLE
Fix AI suggestions flag on import failure

### DIFF
--- a/pages/deep_analytics/analysis_helpers.py
+++ b/pages/deep_analytics/analysis_helpers.py
@@ -24,7 +24,7 @@ except ImportError:  # pragma: no cover - fallback suggestions
             else:
                 suggestions[col] = {"field": "", "confidence": 0.0}
         return suggestions
-    AI_SUGGESTIONS_AVAILABLE = True
+    AI_SUGGESTIONS_AVAILABLE = False
 
 ANALYTICS_SERVICE_AVAILABLE = AnalyticsService is not None
 logger = logging.getLogger(__name__)

--- a/tests/test_analysis_helpers.py
+++ b/tests/test_analysis_helpers.py
@@ -13,3 +13,22 @@ def test_process_suggests_analysis_safe(monkeypatch):
     result = helpers.process_suggests_analysis_safe("upload:test.csv")
     assert result["analysis_type"] == "AI Column Suggestions"
     assert "suggestions" in result
+
+
+def test_ai_suggestions_flag_false_on_import_failure(monkeypatch):
+    import builtins
+    import importlib
+
+    original_import = builtins.__import__
+
+    def fail_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "components.column_verification":
+            raise ImportError("forced failure")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fail_import)
+    module = importlib.reload(helpers)
+    assert module.AI_SUGGESTIONS_AVAILABLE is False
+
+    monkeypatch.setattr(builtins, "__import__", original_import)
+    importlib.reload(helpers)


### PR DESCRIPTION
## Summary
- set `AI_SUGGESTIONS_AVAILABLE` to `False` when the optional import fails
- add a unit test ensuring the flag becomes `False` if the import raises `ImportError`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863b9297c6483208aa2aa44709cca3c