### PR TITLE
Fix file upload route

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,7 +55,7 @@ def print_startup_info(app_config):
     logger.info(f"🔧 Debug Mode: {app_config.debug}")
     logger.info(f"🌍 Environment: {app_config.environment}")
     logger.info(f"Analytics: http://{app_config.host}:{app_config.port}/analytics")
-    logger.info(f"Upload: http://{app_config.host}:{app_config.port}/upload")
+    logger.info(f"Upload: http://{app_config.host}:{app_config.port}/file-upload")
     logger.info("=" * 60)
 
     if app_config.debug:

--- a/core/app_factory.py
+++ b/core/app_factory.py
@@ -257,7 +257,7 @@ def _create_navbar() -> dbc.Navbar:
                                 dbc.NavLink([
                                     html.I(className="fas fa-upload me-1"),
                                     "Upload",
-                                ], href="/upload"),
+                                ], href="/file-upload"),
                             ),
                             dbc.NavItem(
                                 dbc.NavLink([

--- a/pages/file_upload/callbacks.py
+++ b/pages/file_upload/callbacks.py
@@ -41,7 +41,7 @@ def highlight_upload_area(n_clicks):
 
 
 def restore_upload_state(pathname: str) -> Tuple[Any, Any, Any, Any, Any, Any, Any]:
-    if pathname != "/file-upload" or not _uploaded_data_store:
+    if pathname not in ("/file-upload", "/upload") or not _uploaded_data_store:
         return (
             no_update,
             no_update,


### PR DESCRIPTION
## Summary
- update navbar link for file upload page
- handle legacy `/upload` path when restoring file upload state
- correct startup log message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863c80d1b808320a9183d859e5210ea